### PR TITLE
Added Docker build steps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.12
 
-WORKDIR /go/src/compute-aether
+WORKDIR /go/src/aether
 COPY . .
 
 ENV GO111MODULE=on
@@ -8,4 +8,12 @@ ENV GOFLAGS="-mod=vendor"
 
 RUN go install -v ./...
 
-CMD ["compute-aether"]
+
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/src/aether .
+
+CMD ["./aether"]

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -8,4 +8,12 @@ ENV GOFLAGS="-mod=vendor"
 
 RUN go install -v ./...
 
-CMD ["container"]
+
+
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /root/
+COPY --from=0 /go/src/app .
+
+CMD ["./app"]


### PR DESCRIPTION
Reduces image size by more than 90%. This also drastically speeds up e2e testing, due to the slow performance of `kind load docker-image`.